### PR TITLE
Add geocoders

### DIFF
--- a/bin/geocode-array
+++ b/bin/geocode-array
@@ -13,8 +13,8 @@ import argparse
 import collections
 import logging
 
-from geocode_array import ArcGIS, Nominatim, CCT, Google
-from geocode_array import geocode_array, io_utils, STD_OUT, RESULT_KEY
+from geocode_array import ArcGIS, Nominatim, CCT, Google, Bing
+from geocode_array import geocode_array, io_utils, STD_OUT, RESULT_KEY, GOOGLE_API_KEY, BING_API_KEY
 
 parser = argparse.ArgumentParser(
     description="geocode using an array of Geocoders. Example: $ geocode-array  "
@@ -25,7 +25,7 @@ parser.add_argument("--input_filename", type=str, help="input filename eg: sampl
 parser.add_argument("--output_filename", type=str, help="output filename eg: sample_output.csv",
                     default=STD_OUT)
 parser.add_argument("--proxy_url", type=str, help="Proxy URL eg: http://my_username:my_password@my_proxy/", required=False, default=None)
-parser.add_argument("--key_file", type=str, help="your Google API Key in a json file", default=None)
+parser.add_argument("--key_file", type=str, help="your API Keys in a json file", default=None)
 parser.add_argument("--verbose", help="Turns on debug logging", action="store_true", default=False)
 args = parser.parse_args()
 
@@ -39,7 +39,8 @@ log_level = logging.DEBUG if args.verbose else logging.INFO
 logging.basicConfig(level=log_level,
                     format='%(asctime)s-%(module)s.%(funcName)s [%(levelname)s]: %(message)s')
 
-google_api_key = io_utils.get_api_key(key_filename) if key_filename is not None else None
+google_api_key = io_utils.get_api_key(key_filename, GOOGLE_API_KEY) if key_filename is not None else None
+bing_api_key = io_utils.get_api_key(key_filename, BING_API_KEY) if key_filename is not None else None
 
 # Setting up geocoders
 geocoders = collections.OrderedDict([
@@ -52,6 +53,8 @@ geocoders = collections.OrderedDict([
 ])
 if google_api_key is not None:
     geocoders[Google.Google.__name__] = Google.Google(proxy_url=proxy_url, api_key=google_api_key)
+if bing_api_key is not None:
+    geocoders[Bing.Bing.__name__] = Bing.Bing(proxy_url=proxy_url, api_key=bing_api_key)
 
 logging.info(f"Using the following Geocoders: {', '.join(geocoders.keys())}")
 

--- a/geocode_array/Bing.py
+++ b/geocode_array/Bing.py
@@ -21,7 +21,7 @@ class Bing(Geocoder):
         result = _make_request(self.reverse_geocode_url,
                                self._form_reverse_geocode_request_args(*coords),
                                proxy_url=self.proxy_url,
-                               bing_reverse=True)
+                               path_parameters=True)
 
         if result is None:
             return None

--- a/geocode_array/Bing.py
+++ b/geocode_array/Bing.py
@@ -10,7 +10,6 @@ from geocode_array import REQUEST_HEADER_DICT, REQUEST_TRIES, REQUEST_DELAY
 
 def _form_rev_bing_request(request_base_url, request_url_args, proxy_url) -> urllib.request.Request:
         request_string = f"{request_base_url}{request_url_args}"
-        print(request_string)
         req = urllib.request.Request(
             request_string,
             headers={**REQUEST_HEADER_DICT}
@@ -27,7 +26,6 @@ def _make_bing_rev_request(request_base_url, request_url_args, proxy_url) -> str
     logging.debug(f"Request Args: {request_url_args.encode('utf-8')}")
 
     req = _form_rev_bing_request(request_base_url, request_url_args, proxy_url)
-    print("\n", req.full_url, "\n")
     tries = REQUEST_TRIES
     while tries > 0:
         try:
@@ -74,7 +72,7 @@ class Bing(Geocoder):
 
         if result is None:
             return None
-        print(result)
+
         address = self._get_address_from_reverse_geocode(result)
 
         return address

--- a/geocode_array/Bing.py
+++ b/geocode_array/Bing.py
@@ -1,0 +1,120 @@
+import json
+import logging
+import pprint
+import time
+import urllib.parse
+
+from geocode_array.Geocoder import Geocoder
+from geocode_array import REQUEST_HEADER_DICT, REQUEST_TRIES, REQUEST_DELAY
+
+
+def _form_rev_bing_request(request_base_url, request_url_args, proxy_url) -> urllib.request.Request:
+        request_string = f"{request_base_url}{request_url_args}"
+        print(request_string)
+        req = urllib.request.Request(
+            request_string,
+            headers={**REQUEST_HEADER_DICT}
+        )
+        if proxy_url is not None:
+            proxy = urllib.request.ProxyHandler({'http': proxy_url, 'https': proxy_url})
+            auth = urllib.request.HTTPBasicAuthHandler()
+            opener = urllib.request.build_opener(proxy, auth, urllib.request.HTTPHandler)
+            urllib.request.install_opener(opener)
+
+        return req
+
+def _make_bing_rev_request(request_base_url, request_url_args, proxy_url) -> str or None:
+    logging.debug(f"Request Args: {request_url_args.encode('utf-8')}")
+
+    req = _form_rev_bing_request(request_base_url, request_url_args, proxy_url)
+    print("\n", req.full_url, "\n")
+    tries = REQUEST_TRIES
+    while tries > 0:
+        try:
+            resp = urllib.request.urlopen(req)
+            tries = 0
+        except Exception as e:
+            logging.warning(f"URL request failed with {e.__class__}: '{e}'")
+
+            tries -= 1
+            if tries == 0:
+                logging.error("Tries exceeded - giving up")
+                return None
+            else:
+                delay = REQUEST_DELAY*(REQUEST_TRIES-tries+1)
+                logging.debug(f"Sleeping for '{delay}' - {tries} remaining")
+                time.sleep(delay)
+
+    logging.debug(f"Response Code: {resp.getcode()}")
+    code = resp.getcode()
+    
+    if code == 200:
+        resp_raw = resp.read()
+        # logging.debug(f"Raw Result: \n{pprint.pformat(resp_raw)}")
+        result = json.loads(resp_raw.decode('utf-8'))
+        # logging.debug(f"Result: \n{pprint.pformat(result)}")
+    else:
+        logging.debug(f'Got incorrect code: {code}')
+        result = None
+
+    return result
+
+class Bing(Geocoder):
+    reverse_geocode_url = "http://dev.virtualearth.net/REST/v1/Locations/" 
+    geocode_url = "http://dev.virtualearth.net/REST/v1/Locations" 
+
+    def __init__(self, proxy_url=None, api_key=None, **kwargs):
+        super().__init__(proxy_url=proxy_url)
+        self.api_key = api_key
+
+    def _reverse_geocode(self, *coords) -> str or None:
+        result = _make_bing_rev_request(self.reverse_geocode_url,
+                               self._form_reverse_geocode_request_args(*coords),
+                               proxy_url=self.proxy_url)
+
+        if result is None:
+            return None
+        print(result)
+        address = self._get_address_from_reverse_geocode(result)
+
+        return address
+    
+    def _form_reverse_geocode_request_args(self, lat, long) -> str:
+        
+        urlified_values = f"{lat},{long}?&o=json&key={self.api_key}"
+
+        return urlified_values
+
+    def _get_address_from_reverse_geocode(self, response) -> str or None:
+        
+        if 'resourceSets' in response and 'resources' in response['resourceSets'][0] and len(response['resourceSets'][0]['resources']) > 0:
+            first_result = response['resourceSets'][0]['resources'][0]['address']
+            address = first_result['formattedAddress']
+        else:
+            address = None
+
+        return address
+
+    def _form_geocode_request_args(self, address) -> str:
+        values = {
+            "q": address,
+            "o": "json",
+            "key": self.api_key,
+        }
+        logging.debug(f"geocode values={pprint.pformat(values)}")
+
+        urlified_values = urllib.parse.urlencode(values)
+
+        return urlified_values
+
+    def _get_coords_from_geocode(self, response) -> (float, float) or (None, None):
+        
+        if 'resourceSets' in response and 'resources' in response['resourceSets'][0] and len(response['resourceSets'][0]['resources']) > 0:
+            first_result = response['resourceSets'][0]['resources'][0]['point']['coordinates']
+            lat = float(first_result[0])
+            long = float(first_result[1])
+        else:
+            lat = None
+            long = None
+
+        return lat, long

--- a/geocode_array/Bing.py
+++ b/geocode_array/Bing.py
@@ -4,60 +4,9 @@ import pprint
 import time
 import urllib.parse
 
-from geocode_array.Geocoder import Geocoder
+from geocode_array.Geocoder import Geocoder, _make_request
 from geocode_array import REQUEST_HEADER_DICT, REQUEST_TRIES, REQUEST_DELAY
 
-
-def _form_rev_bing_request(request_base_url, request_url_args, proxy_url) -> urllib.request.Request:
-        request_string = f"{request_base_url}{request_url_args}"
-        print(request_string)
-        req = urllib.request.Request(
-            request_string,
-            headers={**REQUEST_HEADER_DICT}
-        )
-        if proxy_url is not None:
-            proxy = urllib.request.ProxyHandler({'http': proxy_url, 'https': proxy_url})
-            auth = urllib.request.HTTPBasicAuthHandler()
-            opener = urllib.request.build_opener(proxy, auth, urllib.request.HTTPHandler)
-            urllib.request.install_opener(opener)
-
-        return req
-
-def _make_bing_rev_request(request_base_url, request_url_args, proxy_url) -> str or None:
-    logging.debug(f"Request Args: {request_url_args.encode('utf-8')}")
-
-    req = _form_rev_bing_request(request_base_url, request_url_args, proxy_url)
-    print("\n", req.full_url, "\n")
-    tries = REQUEST_TRIES
-    while tries > 0:
-        try:
-            resp = urllib.request.urlopen(req)
-            tries = 0
-        except Exception as e:
-            logging.warning(f"URL request failed with {e.__class__}: '{e}'")
-
-            tries -= 1
-            if tries == 0:
-                logging.error("Tries exceeded - giving up")
-                return None
-            else:
-                delay = REQUEST_DELAY*(REQUEST_TRIES-tries+1)
-                logging.debug(f"Sleeping for '{delay}' - {tries} remaining")
-                time.sleep(delay)
-
-    logging.debug(f"Response Code: {resp.getcode()}")
-    code = resp.getcode()
-    
-    if code == 200:
-        resp_raw = resp.read()
-        # logging.debug(f"Raw Result: \n{pprint.pformat(resp_raw)}")
-        result = json.loads(resp_raw.decode('utf-8'))
-        # logging.debug(f"Result: \n{pprint.pformat(result)}")
-    else:
-        logging.debug(f'Got incorrect code: {code}')
-        result = None
-
-    return result
 
 class Bing(Geocoder):
     reverse_geocode_url = "http://dev.virtualearth.net/REST/v1/Locations/" 
@@ -67,14 +16,16 @@ class Bing(Geocoder):
         super().__init__(proxy_url=proxy_url)
         self.api_key = api_key
 
+    # overwrite the _reverse_geocode method for Bing
     def _reverse_geocode(self, *coords) -> str or None:
-        result = _make_bing_rev_request(self.reverse_geocode_url,
+        result = _make_request(self.reverse_geocode_url,
                                self._form_reverse_geocode_request_args(*coords),
-                               proxy_url=self.proxy_url)
+                               proxy_url=self.proxy_url,
+                               bing_reverse=True)
 
         if result is None:
             return None
-        print(result)
+
         address = self._get_address_from_reverse_geocode(result)
 
         return address

--- a/geocode_array/Geocoder.py
+++ b/geocode_array/Geocoder.py
@@ -8,8 +8,11 @@ import urllib.request
 from geocode_array import REQUEST_HEADER_DICT, REQUEST_TRIES, REQUEST_DELAY
 
 
-def _form_request(request_base_url, request_url_args, proxy_url) -> urllib.request.Request:
-    request_string = f"{request_base_url}?{request_url_args}"
+def _form_request(request_base_url, request_url_args, proxy_url, bing_reverse=False) -> urllib.request.Request:
+    if bing_reverse:
+        request_string = f"{request_base_url}{request_url_args}"
+    else:    
+        request_string = f"{request_base_url}?{request_url_args}"
     req = urllib.request.Request(
         request_string,
         headers={**REQUEST_HEADER_DICT}
@@ -23,10 +26,10 @@ def _form_request(request_base_url, request_url_args, proxy_url) -> urllib.reque
     return req
 
 
-def _make_request(request_base_url, request_url_args, proxy_url) -> str or None:
+def _make_request(request_base_url, request_url_args, proxy_url, bing_reverse=False) -> str or None:
     logging.debug(f"Request Args: {request_url_args.encode('utf-8')}")
 
-    req = _form_request(request_base_url, request_url_args, proxy_url)
+    req = _form_request(request_base_url, request_url_args, proxy_url, bing_reverse)
 
     tries = REQUEST_TRIES
     while tries > 0:
@@ -93,10 +96,11 @@ class Geocoder:
     def _get_address_from_reverse_geocode(self, response) -> str or None:
         raise NotImplementedError
 
-    def _reverse_geocode(self, *coords) -> str or None:
+    def _reverse_geocode(self, *coords, bing_reverse=False) -> str or None:
         result = _make_request(self.reverse_geocode_url,
                                self._form_reverse_geocode_request_args(*coords),
-                               proxy_url=self.proxy_url)
+                               proxy_url=self.proxy_url,
+                               bing_reverse=bing_reverse)
 
         if result is None:
             return None

--- a/geocode_array/Geocoder.py
+++ b/geocode_array/Geocoder.py
@@ -8,8 +8,8 @@ import urllib.request
 from geocode_array import REQUEST_HEADER_DICT, REQUEST_TRIES, REQUEST_DELAY
 
 
-def _form_request(request_base_url, request_url_args, proxy_url, bing_reverse=False) -> urllib.request.Request:
-    if bing_reverse:
+def _form_request(request_base_url, request_url_args, proxy_url, path_parameters=False) -> urllib.request.Request:
+    if path_parameters:
         request_string = f"{request_base_url}{request_url_args}"
     else:    
         request_string = f"{request_base_url}?{request_url_args}"
@@ -26,10 +26,10 @@ def _form_request(request_base_url, request_url_args, proxy_url, bing_reverse=Fa
     return req
 
 
-def _make_request(request_base_url, request_url_args, proxy_url, bing_reverse=False) -> str or None:
+def _make_request(request_base_url, request_url_args, proxy_url, path_parameters=False) -> str or None:
     logging.debug(f"Request Args: {request_url_args.encode('utf-8')}")
 
-    req = _form_request(request_base_url, request_url_args, proxy_url, bing_reverse)
+    req = _form_request(request_base_url, request_url_args, proxy_url, path_parameters)
 
     tries = REQUEST_TRIES
     while tries > 0:
@@ -96,11 +96,11 @@ class Geocoder:
     def _get_address_from_reverse_geocode(self, response) -> str or None:
         raise NotImplementedError
 
-    def _reverse_geocode(self, *coords, bing_reverse=False) -> str or None:
+    def _reverse_geocode(self, *coords, path_parameters=False) -> str or None:
         result = _make_request(self.reverse_geocode_url,
                                self._form_reverse_geocode_request_args(*coords),
                                proxy_url=self.proxy_url,
-                               bing_reverse=bing_reverse)
+                               path_parameters=path_parameters)
 
         if result is None:
             return None

--- a/geocode_array/What3Words.py
+++ b/geocode_array/What3Words.py
@@ -1,0 +1,56 @@
+import logging
+import pprint
+import urllib.parse
+
+from geocode_array.Geocoder import Geocoder
+
+
+class what3words(Geocoder):
+    reverse_geocode_url = "https://api.what3words.com/v3/convert-to-3wa"
+    geocode_url = "https://api.what3words.com/v3/convert-to-coordinates" 
+
+    def __init__(self, proxy_url=None, api_key=None, **kwargs):
+        super().__init__(proxy_url=proxy_url)
+        self.api_key = api_key
+
+
+    def _form_reverse_geocode_request_args(self, lat, long) -> str:
+        values = {
+            "coordinates": f'{lat},{long}',
+            "key": self.api_key
+        }
+        logging.debug(f"reverse geocode values={pprint.pformat(values)}")
+
+        urlified_values = urllib.parse.urlencode(values)
+
+        return urlified_values
+
+    def _get_address_from_reverse_geocode(self, response) -> str or None:
+        if 'words' in response and len(response['words']) > 0:
+            address = response['words']
+        else:
+            address = None
+
+        return address
+
+    def _form_geocode_request_args(self, the_three_words) -> str:
+        values = {
+            "words": f'{the_three_words}',
+            "key": self.api_key
+        }
+        logging.debug(f"geocode values={pprint.pformat(values)}")
+
+        urlified_values = urllib.parse.urlencode(values)
+        
+        return urlified_values
+
+    def _get_coords_from_geocode(self, response) -> (float, float) or (None, None):
+        if 'coordinates' in response and len(response['coordinates']) > 0:
+            first_result = response['coordinates']
+            lat = float(first_result['lat'])
+            long = float(first_result['lng'])
+        else:
+            lat = None
+            long = None
+
+        return lat, long

--- a/geocode_array/What3Words.py
+++ b/geocode_array/What3Words.py
@@ -1,5 +1,6 @@
 import logging
 import pprint
+import re
 import urllib.parse
 
 from geocode_array.Geocoder import Geocoder
@@ -34,6 +35,8 @@ class what3words(Geocoder):
         return address
 
     def _form_geocode_request_args(self, the_three_words) -> str:
+        if not re.match("^\w+\.\w+\.\w+$" , the_three_words):
+            raise ValueError("what3 words expects three '.' separated words")
         values = {
             "words": f'{the_three_words}',
             "key": self.api_key

--- a/geocode_array/__init__.py
+++ b/geocode_array/__init__.py
@@ -6,7 +6,9 @@ STD_OUT = "/dev/stdout"
 ADDRESS_ID_FIELD = "Address_ID"
 ADDRESS_FIELD = "Address_Cleaned"
 
-API_KEY = "api_key"
+GOOGLE_API_KEY = "google_api_key"
+BING_API_KEY = "bing_api_key"
+W3W_API_KEY = "w3w_api_key"
 
 RESULT_KEY = "result"
 

--- a/geocode_array/io_utils.py
+++ b/geocode_array/io_utils.py
@@ -131,4 +131,7 @@ def get_api_key(key_filename, api_key):
     with open(key_filename, "r") as key_file:
         key_data = json.load(key_file)
 
+    if api_key not in key_data.keys():
+        raise KeyError(f"API key name: {api_key} not found in {key_filename} keys: {key_data.keys()}")
+
     return key_data[api_key]

--- a/geocode_array/io_utils.py
+++ b/geocode_array/io_utils.py
@@ -13,7 +13,7 @@ import logging
 import os
 import pprint
 
-from geocode_array import JSON_EXT, CSV_EXT, STD_OUT, ADDRESS_ID_FIELD, ADDRESS_FIELD, RESULT_KEY, API_KEY
+from geocode_array import JSON_EXT, CSV_EXT, STD_OUT, ADDRESS_ID_FIELD, ADDRESS_FIELD, RESULT_KEY, GOOGLE_API_KEY, BING_API_KEY, W3W_API_KEY 
 
 DATA_READER_DICT = {
     JSON_EXT: lambda input_file: iter(json.load(input_file)),
@@ -127,8 +127,8 @@ def output_data(data, output_filename):
         data_writer_func(data_file, data)
 
 
-def get_api_key(key_filename):
+def get_api_key(key_filename, api_key):
     with open(key_filename, "r") as key_file:
         key_data = json.load(key_file)
 
-    return key_data[API_KEY]
+    return key_data[api_key]

--- a/resources/key.json
+++ b/resources/key.json
@@ -1,1 +1,5 @@
-{"api_key": "<insert google api key here>"}
+{
+    "google_api_key": "<insert google api key here>",
+    "bing_api_key": "<insert bing api key here>",
+    "w3w_api_key": "<insert what3words api key here>"
+}


### PR DESCRIPTION
Added modules for Bing and What3Words geocoders (Both have non payment requiring API keys)

Updated `io_utils.py`, `__init__.py` and the `key.json` to allow the additional api keys

Bing required a bit of a workaround since it's reverse geocode format was not the same as the others.

It wants a literal `,` between the lat and long followed by a literal `?`  not the url-ified % versions of those characters, and no keyword before the lat long.

This required overwriting the following `Geocoder.py` functions in `Bing.py` for reverse geocoding only. 

called from `_reverse_geocode`:
* `_form_request` remapped as ``_form_rev_bing_request`
* `_make_request` remapped as `_make_bing_rev_request`

```
from geocode_array.Bing import Bing
bing = Bing(api_key=bing_key)
points = bing.geocode("5 Clovelly Ave, Cape Town, 8001")
address = bing._reverse_geocode(-33.934498,18.4257403)
```
and
```
from geocode_array.What3Words import what3words
w3w= what3words(api_key=w3w_key)
points = w3w.geocode("budged.specified.pentagonal")
three_words = w3w._reverse_geocode(-33.934498,18.4257403)
```
